### PR TITLE
Fix to strings WriteCode exercise answer check and prompt

### DIFF
--- a/_sources/strings/WriteCode.rst
+++ b/_sources/strings/WriteCode.rst
@@ -208,7 +208,7 @@ Write Code Questions
 
         Write code to print out the statement "Hi my name is Bob and I am 2" using only string methods
         or string slicing. You must get every part of the new string from the given strings, not by using
-	string literals.
+        string literals.
         Name the final string ``statement``.
         ~~~~
         s1 = "hi"

--- a/_sources/strings/WriteCode.rst
+++ b/_sources/strings/WriteCode.rst
@@ -206,8 +206,9 @@ Write Code Questions
     .. activecode::  str-ex-nameq
         :nocodelens:
 
-        Write code to print out the statement "Hi, my name is Bob, and I am 2" using only string methods
-        or string slicing. You must get every part of the new string from the given strings.
+        Write code to print out the statement "Hi my name is Bob and I am 2" using only string methods
+        or string slicing. You must get every part of the new string from the given strings, not by using
+	string literals.
         Name the final string ``statement``.
         ~~~~
         s1 = "hi"


### PR DESCRIPTION
Just a quick and dirty fix for the answer check for the str-ex-nameq exercise that didn't include the commas from the original prompt.  I also edited the prompt for clarity.